### PR TITLE
Use the ActiveMQ Convention of Distinguishing between TextMessage and BytesMessage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>1.0.0</version>
+        <version>5.1.9</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   
   <groupId>org.fusesource.stompjms</groupId>
   <artifactId>stompjms-project</artifactId>
-  <version>1.20-SNAPSHOT</version>
+  <version>1.21-SNAPSHOT</version>
   <packaging>pom</packaging>
   
   <name>${project.artifactId}</name>
@@ -35,11 +35,11 @@
     <forge-project-id-uc>STOMPJMS</forge-project-id-uc>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     
-    <junit-version>4.7</junit-version>
-    <slf4j-version>1.6.1</slf4j-version>
-    <hawtbuf-version>1.9</hawtbuf-version>
-    <hawtdispatch-version>1.20</hawtdispatch-version>
-    <apollo-version>1.6</apollo-version>
+    <junit-version>4.13.2</junit-version>
+    <slf4j-version>1.7.36</slf4j-version>
+    <hawtbuf-version>1.11</hawtbuf-version>
+    <hawtdispatch-version>1.22</hawtdispatch-version>
+    <apollo-version>1.7.1</apollo-version>
     <activemq-version>5.9.0</activemq-version>
     <mvnplugins-version>1.15</mvnplugins-version>
     <mockito.version>1.9.5</mockito.version>
@@ -149,8 +149,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
       <plugin>
@@ -261,7 +261,7 @@
 
   <modules>
     <module>stompjms-client</module>
-    <module>stompjms-website</module>
+    <!--<module>stompjms-website</module>-->
     <module>stompjms-activemq-test</module>
   </modules>
     

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <description>
       STOMP-JMS is a JMS implementation using STOMP as the wire protocol
   </description>
-  
+
   <properties>
     <forge-project-id>stompjms</forge-project-id>
     <forge-project-id-uc>STOMPJMS</forge-project-id-uc>
@@ -83,14 +83,6 @@
     <developerConnection>scm:git:ssh://git@forge.fusesource.com/${forge-project-id}.git</developerConnection>
     <url>http://github.com/fusesource/stompjms/tree/master</url>
   </scm>
-
-  <distributionManagement>
-    <site>
-      <id>website.fusesource.org</id>
-      <name>website</name>
-      <url>dav:http://fusesource.com/forge/dav/${forge-project-id}/maven/${project.version}</url>
-    </site>
-  </distributionManagement>
 
   <developers>
     <developer>
@@ -264,5 +256,13 @@
     <!--<module>stompjms-website</module>-->
     <module>stompjms-activemq-test</module>
   </modules>
+
+  <distributionManagement>
+  <repository>
+    <id>clojars</id>
+    <name>Clojars repository</name>
+    <url>https://clojars.org/repo</url>
+  </repository>
+  </distributionManagement>
     
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <hawtbuf-version>1.11</hawtbuf-version>
     <hawtdispatch-version>1.22</hawtdispatch-version>
     <apollo-version>1.7.1</apollo-version>
-    <activemq-version>5.9.0</activemq-version>
+    <activemq-version>6.1.3</activemq-version>
     <mvnplugins-version>1.15</mvnplugins-version>
     <mockito.version>1.9.5</mockito.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   
   <groupId>org.fusesource.stompjms</groupId>
   <artifactId>stompjms-project</artifactId>
-  <version>1.21-SNAPSHOT</version>
+  <version>1.21</version>
   <packaging>pom</packaging>
   
   <name>${project.artifactId}</name>

--- a/stompjms-activemq-test/pom.xml
+++ b/stompjms-activemq-test/pom.xml
@@ -69,6 +69,12 @@
       <version>1.4.20</version>
     </dependency>
 
+    <dependency>
+        <groupId>jakarta.jms</groupId>
+        <artifactId>jakarta.jms-api</artifactId>
+        <version>3.1.0</version>
+    </dependency>
+
     <!-- to enable the webconsole in the apollo broker -->
     <dependency>
       <groupId>junit</groupId>

--- a/stompjms-activemq-test/pom.xml
+++ b/stompjms-activemq-test/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.fusesource.stompjms</groupId>
     <artifactId>stompjms-project</artifactId>
-    <version>1.21-SNAPSHOT</version>
+    <version>1.21</version>
   </parent>
   
   <groupId>org.fusesource.stompjms</groupId>
   <artifactId>stompjms-activemq-test</artifactId>
-  <version>1.21-SNAPSHOT</version>
+  <version>1.21</version>
   
   <name>${project.artifactId}</name>
   <description>Tests the stompjms client against ActiveMQ</description>

--- a/stompjms-activemq-test/pom.xml
+++ b/stompjms-activemq-test/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.fusesource.stompjms</groupId>
     <artifactId>stompjms-project</artifactId>
-    <version>1.20-SNAPSHOT</version>
+    <version>1.21-SNAPSHOT</version>
   </parent>
   
   <groupId>org.fusesource.stompjms</groupId>
   <artifactId>stompjms-activemq-test</artifactId>
-  <version>1.20-SNAPSHOT</version>
+  <version>1.21-SNAPSHOT</version>
   
   <name>${project.artifactId}</name>
   <description>Tests the stompjms client against ActiveMQ</description>
@@ -32,14 +32,14 @@
     <dependency>
       <groupId>org.fusesource.stompjms</groupId>
       <artifactId>stompjms-client</artifactId>
-      <version>1.20-SNAPSHOT</version>
+      <version>1.21-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jms_1.1_spec</artifactId>
-      <version>1.1</version>
+      <version>1.1.1</version>
       <scope>test</scope>
     </dependency>
 
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.4</version>
+      <version>1.4.20</version>
     </dependency>
 
     <!-- to enable the webconsole in the apollo broker -->

--- a/stompjms-activemq-test/src/test/java/org/fusesource/stomp/activemq/ActiveMQJmsStompTest.java
+++ b/stompjms-activemq-test/src/test/java/org/fusesource/stomp/activemq/ActiveMQJmsStompTest.java
@@ -14,7 +14,7 @@ import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.TransportConnector;
 import org.fusesource.stomp.jms.StompJmsConnectionFactory;
 
-import javax.jms.*;
+import jakarta.jms.*;
 
 /**
  * <p>

--- a/stompjms-client/pom.xml
+++ b/stompjms-client/pom.xml
@@ -29,6 +29,12 @@
   <description>
         STOMP-JMS is a JMS implementation using STOMP as the wire protocol
   </description>
+
+  <licenses>
+  <license>
+    <name>CDDL 1.0</name>
+  </license>
+  </licenses>
   
   <dependencies>
 
@@ -183,5 +189,13 @@
       </plugin>
     </plugins>
   </build>
+
+  <distributionManagement>
+  <repository>
+    <id>clojars</id>
+    <name>Clojars repository</name>
+    <url>https://clojars.org/repo</url>
+  </repository>
+  </distributionManagement>
       
 </project>

--- a/stompjms-client/pom.xml
+++ b/stompjms-client/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.eclipse.jetty.aggregate</groupId>
       <artifactId>jetty-all-server</artifactId>
-      <version>7.1.6.v20100715</version>
+      <version>8.2.0.v20160908</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/stompjms-client/pom.xml
+++ b/stompjms-client/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.fusesource.stompjms</groupId>
     <artifactId>stompjms-project</artifactId>
-    <version>1.21-SNAPSHOT</version>
+    <version>1.21</version>
   </parent>
   
   <groupId>org.fusesource.stompjms</groupId>
   <artifactId>stompjms-client</artifactId>
-  <version>1.21-SNAPSHOT</version>
+  <version>1.21</version>
   <packaging>bundle</packaging>
   
   <name>${project.artifactId}</name>

--- a/stompjms-client/pom.xml
+++ b/stompjms-client/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.fusesource.stompjms</groupId>
     <artifactId>stompjms-project</artifactId>
-    <version>1.20-SNAPSHOT</version>
+    <version>1.21-SNAPSHOT</version>
   </parent>
   
   <groupId>org.fusesource.stompjms</groupId>
   <artifactId>stompjms-client</artifactId>
-  <version>1.20-SNAPSHOT</version>
+  <version>1.21-SNAPSHOT</version>
   <packaging>bundle</packaging>
   
   <name>${project.artifactId}</name>
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
       <artifactId>geronimo-jms_1.1_spec</artifactId>
-      <version>1.1</version>
+      <version>1.1.1</version>
       <optional>true</optional>
     </dependency>
 
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.3.1</version>
+      <version>1.4.20</version>
       <optional>true</optional>
     </dependency>
     

--- a/stompjms-client/pom.xml
+++ b/stompjms-client/pom.xml
@@ -51,6 +51,12 @@
     </dependency>
 
     <dependency>
+        <groupId>jakarta.jms</groupId>
+        <artifactId>jakarta.jms-api</artifactId>
+        <version>3.1.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>apollo-selector</artifactId>
       <version>${apollo-version}</version>

--- a/stompjms-client/pom.xml
+++ b/stompjms-client/pom.xml
@@ -22,7 +22,7 @@
   
   <groupId>org.fusesource.stompjms</groupId>
   <artifactId>stompjms-client</artifactId>
-  <version>1.21</version>
+  <version>1.22</version>
   <packaging>bundle</packaging>
   
   <name>${project.artifactId}</name>
@@ -30,10 +30,12 @@
         STOMP-JMS is a JMS implementation using STOMP as the wire protocol
   </description>
 
+
   <licenses>
-  <license>
-    <name>CDDL 1.0</name>
-  </license>
+    <license>
+      <name>Common Development and Distribution License (CDDL)</name>
+      <url>http://www.opensource.org/licenses/cddl1</url>
+    </license>
   </licenses>
   
   <dependencies>

--- a/stompjms-client/src/main/java/org/fusesource/stomp/client/CallbackConnection.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/client/CallbackConnection.java
@@ -178,17 +178,10 @@ public class CallbackConnection {
     }
 
     public boolean offer(StompFrame frame) {
-        return this.offer(frame, true);
-    }
-
-    public boolean offer(StompFrame frame, boolean addContentLength) {
         getDispatchQueue().assertExecuting();
         if( this.transport.full() ) {
             return false;
         } else {
-            if( addContentLength && SEND.equals(frame.action()) ) {
-                frame.addContentLengthHeader();
-            }
             return this.transport.offer(frame);
         }
     }

--- a/stompjms-client/src/main/java/org/fusesource/stomp/codec/StompFrame.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/codec/StompFrame.java
@@ -194,10 +194,6 @@ public class StompFrame {
         write(out, true);
     }
 
-    public void addContentLengthHeader() {
-        addHeader(CONTENT_LENGTH, new AsciiBuffer(Integer.toString(content.length())));
-    }
-
     public int size() {
         int rc = action.length() + 1;
         if( headerList!=null ) {

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/ActiveMQServerAdaptor.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/ActiveMQServerAdaptor.java
@@ -11,7 +11,7 @@ package org.fusesource.stomp.jms;
 
 import org.fusesource.hawtbuf.AsciiBuffer;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 import java.util.Map;
 
 import static org.fusesource.stomp.client.Constants.*;

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/ApolloServerAdaptor.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/ApolloServerAdaptor.java
@@ -13,9 +13,9 @@ import org.fusesource.hawtbuf.AsciiBuffer;
 import org.fusesource.hawtbuf.Buffer;
 import org.fusesource.stomp.codec.StompFrame;
 
-import javax.jms.JMSException;
-import javax.jms.TemporaryQueue;
-import javax.jms.TemporaryTopic;
+import jakarta.jms.JMSException;
+import jakarta.jms.TemporaryQueue;
+import jakarta.jms.TemporaryTopic;
 
 import java.util.Map;
 import java.util.UUID;

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/RabbitMQServerAdaptor.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/RabbitMQServerAdaptor.java
@@ -7,7 +7,7 @@ import static org.fusesource.stomp.client.Constants.UNSUBSCRIBE;
 
 import java.util.Map;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 import org.fusesource.hawtbuf.AsciiBuffer;
 import org.fusesource.stomp.codec.StompFrame;

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompChannel.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompChannel.java
@@ -53,6 +53,7 @@ import org.fusesource.stomp.client.ProtocolException;
 import org.fusesource.stomp.client.Stomp;
 import org.fusesource.stomp.codec.StompFrame;
 import org.fusesource.stomp.jms.message.StompJmsMessage;
+import org.fusesource.stomp.jms.message.StompJmsTextMessage;
 import org.fusesource.stomp.jms.util.StompTranslator;
 
 public class StompChannel {
@@ -215,7 +216,9 @@ public class StompChannel {
         copy.onSend();
         StompFrame frame = copy.getFrame();
         frame.action(SEND);
-        frame.headerMap().put(CONTENT_LENGTH, new AsciiBuffer(Integer.toString(frame.content().length)));
+        if (!(copy instanceof StompJmsTextMessage)) {
+            frame.headerMap().put(CONTENT_LENGTH, new AsciiBuffer(Integer.toString(frame.content().length)));
+        }
         if (txid != null) {
             frame.headerMap().put(TRANSACTION, txid);
         }

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompChannel.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompChannel.java
@@ -40,8 +40,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.jms.ExceptionListener;
-import javax.jms.JMSException;
+import jakarta.jms.ExceptionListener;
+import jakarta.jms.JMSException;
 import javax.net.ssl.SSLContext;
 
 import org.fusesource.hawtbuf.AsciiBuffer;

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsConnection.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsConnection.java
@@ -10,8 +10,8 @@
 
 package org.fusesource.stomp.jms;
 
-import javax.jms.*;
-import javax.jms.IllegalStateException;
+import jakarta.jms.*;
+import jakarta.jms.IllegalStateException;
 import javax.net.ssl.SSLContext;
 import java.net.URI;
 import java.util.List;
@@ -66,7 +66,7 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
 
     /**
      * @throws JMSException
-     * @see javax.jms.Connection#close()
+     * @see jakarta.jms.Connection#close()
      */
     public synchronized void close() throws JMSException {
         if (closed.compareAndSet(false, true)) {
@@ -92,8 +92,8 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
      * @param maxMessages
      * @return ConnectionConsumer
      * @throws JMSException
-     * @see javax.jms.Connection#createConnectionConsumer(javax.jms.Destination,
-     *      java.lang.String, javax.jms.ServerSessionPool, int)
+     * @see jakarta.jms.Connection#createConnectionConsumer(jakarta.jms.Destination,
+     *      java.lang.String, jakarta.jms.ServerSessionPool, int)
      */
     public ConnectionConsumer createConnectionConsumer(Destination destination, String messageSelector,
                                                        ServerSessionPool sessionPool, int maxMessages) throws JMSException {
@@ -110,8 +110,8 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
      * @param maxMessages
      * @return ConnectionConsumer
      * @throws JMSException
-     * @see javax.jms.Connection#createDurableConnectionConsumer(javax.jms.Topic,
-     *      java.lang.String, java.lang.String, javax.jms.ServerSessionPool,
+     * @see jakarta.jms.Connection#createDurableConnectionConsumer(jakarta.jms.Topic,
+     *      java.lang.String, java.lang.String, jakarta.jms.ServerSessionPool,
      *      int)
      */
     public ConnectionConsumer createDurableConnectionConsumer(Topic topic, String subscriptionName,
@@ -126,7 +126,7 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
      * @param acknowledgeMode
      * @return Session
      * @throws JMSException
-     * @see javax.jms.Connection#createSession(boolean, int)
+     * @see jakarta.jms.Connection#createSession(boolean, int)
      */
     public synchronized Session createSession(boolean transacted, int acknowledgeMode) throws JMSException {
         checkClosed();
@@ -142,7 +142,7 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
 
     /**
      * @return clientId
-     * @see javax.jms.Connection#getClientID()
+     * @see jakarta.jms.Connection#getClientID()
      */
     public String getClientID() {
         return this.clientId;
@@ -150,7 +150,7 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
 
     /**
      * @return ExceptionListener
-     * @see javax.jms.Connection#getExceptionListener()
+     * @see jakarta.jms.Connection#getExceptionListener()
      */
     public ExceptionListener getExceptionListener() {
         return this.exceptionListener;
@@ -158,7 +158,7 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
 
     /**
      * @return ConnectionMetaData
-     * @see javax.jms.Connection#getMetaData()
+     * @see jakarta.jms.Connection#getMetaData()
      */
     public ConnectionMetaData getMetaData() {
         return StompJmsConnectionMetaData.INSTANCE;
@@ -167,7 +167,7 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
     /**
      * @param clientID
      * @throws JMSException
-     * @see javax.jms.Connection#setClientID(java.lang.String)
+     * @see jakarta.jms.Connection#setClientID(java.lang.String)
      */
     public synchronized void setClientID(String clientID) throws JMSException {
         if (this.clientIdSet) {
@@ -185,7 +185,7 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
 
     /**
      * @param listener
-     * @see javax.jms.Connection#setExceptionListener(javax.jms.ExceptionListener)
+     * @see jakarta.jms.Connection#setExceptionListener(jakarta.jms.ExceptionListener)
      */
     public void setExceptionListener(ExceptionListener listener) {
         this.exceptionListener = listener;
@@ -193,7 +193,7 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
 
     /**
      * @throws JMSException
-     * @see javax.jms.Connection#start()
+     * @see jakarta.jms.Connection#start()
      */
     public void start() throws JMSException {
         checkClosed();
@@ -211,7 +211,7 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
 
     /**
      * @throws JMSException
-     * @see javax.jms.Connection#stop()
+     * @see jakarta.jms.Connection#stop()
      */
     public void stop() throws JMSException {
         checkClosed();
@@ -234,8 +234,8 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
      * @param maxMessages
      * @return ConnectionConsumer
      * @throws JMSException
-     * @see javax.jms.TopicConnection#createConnectionConsumer(javax.jms.Topic,
-     *      java.lang.String, javax.jms.ServerSessionPool, int)
+     * @see jakarta.jms.TopicConnection#createConnectionConsumer(jakarta.jms.Topic,
+     *      java.lang.String, jakarta.jms.ServerSessionPool, int)
      */
     public ConnectionConsumer createConnectionConsumer(Topic topic, String messageSelector,
                                                        ServerSessionPool sessionPool, int maxMessages) throws JMSException {
@@ -249,7 +249,7 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
      * @param acknowledgeMode
      * @return TopicSession
      * @throws JMSException
-     * @see javax.jms.TopicConnection#createTopicSession(boolean, int)
+     * @see jakarta.jms.TopicConnection#createTopicSession(boolean, int)
      */
     public TopicSession createTopicSession(boolean transacted, int acknowledgeMode) throws JMSException {
         checkClosed();
@@ -270,8 +270,8 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
      * @param maxMessages
      * @return ConnectionConsumer
      * @throws JMSException
-     * @see javax.jms.QueueConnection#createConnectionConsumer(javax.jms.Queue,
-     *      java.lang.String, javax.jms.ServerSessionPool, int)
+     * @see jakarta.jms.QueueConnection#createConnectionConsumer(jakarta.jms.Queue,
+     *      java.lang.String, jakarta.jms.ServerSessionPool, int)
      */
     public ConnectionConsumer createConnectionConsumer(Queue queue, String messageSelector,
                                                        ServerSessionPool sessionPool, int maxMessages) throws JMSException {
@@ -285,7 +285,7 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
      * @param acknowledgeMode
      * @return QueueSession
      * @throws JMSException
-     * @see javax.jms.QueueConnection#createQueueSession(boolean, int)
+     * @see jakarta.jms.QueueConnection#createQueueSession(boolean, int)
      */
     public QueueSession createQueueSession(boolean transacted, int acknowledgeMode) throws JMSException {
         checkClosed();
@@ -481,5 +481,24 @@ public class StompJmsConnection implements Connection, TopicConnection, QueueCon
 
     public void setDisconnectTimeout(long disconnectTimeout) {
         this.disconnectTimeout = disconnectTimeout;
+    }
+
+    /*
+     * New Methods from switching to jakarta.jms.
+     */
+    public Session createSession() {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public Session createSession(int i) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public ConnectionConsumer createSharedConnectionConsumer(Topic t, String s1, String s2, ServerSessionPool ssp, int i) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public ConnectionConsumer createSharedDurableConnectionConsumer(Topic t, String s1, String s2, ServerSessionPool ssp, int i) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
     }
 }

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsConnectionClosedException.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsConnectionClosedException.java
@@ -10,7 +10,7 @@
 
 package org.fusesource.stomp.jms;
 
-import javax.jms.IllegalStateException;
+import jakarta.jms.IllegalStateException;
 
 /**
  * An exception thrown when attempt is made to use a connection when the connection has been closed.

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsConnectionFactory.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsConnectionFactory.java
@@ -14,7 +14,7 @@ package org.fusesource.stomp.jms;
 import org.fusesource.stomp.jms.jndi.JNDIStorable;
 import org.fusesource.stomp.jms.util.PropertyUtil;
 
-import javax.jms.*;
+import jakarta.jms.*;
 import javax.net.ssl.SSLContext;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -92,7 +92,7 @@ public class StompJmsConnectionFactory extends JNDIStorable implements Connectio
     /**
      * @return a TopicConnection
      * @throws JMSException
-     * @see javax.jms.TopicConnectionFactory#createTopicConnection()
+     * @see jakarta.jms.TopicConnectionFactory#createTopicConnection()
      */
     public TopicConnection createTopicConnection() throws JMSException {
         return createTopicConnection( getUsername(), getPassword());
@@ -103,7 +103,7 @@ public class StompJmsConnectionFactory extends JNDIStorable implements Connectio
      * @param password
      * @return a TopicConnection
      * @throws JMSException
-     * @see javax.jms.TopicConnectionFactory#createTopicConnection(java.lang.String, java.lang.String)
+     * @see jakarta.jms.TopicConnectionFactory#createTopicConnection(java.lang.String, java.lang.String)
      */
     public TopicConnection createTopicConnection(String userName, String password) throws JMSException {
         try {
@@ -118,7 +118,7 @@ public class StompJmsConnectionFactory extends JNDIStorable implements Connectio
     /**
      * @return a Connection
      * @throws JMSException
-     * @see javax.jms.ConnectionFactory#createConnection()
+     * @see jakarta.jms.ConnectionFactory#createConnection()
      */
     public Connection createConnection() throws JMSException {
         return createConnection(getUsername(), getPassword());
@@ -129,7 +129,7 @@ public class StompJmsConnectionFactory extends JNDIStorable implements Connectio
      * @param password
      * @return Connection
      * @throws JMSException
-     * @see javax.jms.ConnectionFactory#createConnection(java.lang.String, java.lang.String)
+     * @see jakarta.jms.ConnectionFactory#createConnection(java.lang.String, java.lang.String)
      */
     public Connection createConnection(String userName, String password) throws JMSException {
         try {
@@ -144,7 +144,7 @@ public class StompJmsConnectionFactory extends JNDIStorable implements Connectio
     /**
      * @return a QueueConnection
      * @throws JMSException
-     * @see javax.jms.QueueConnectionFactory#createQueueConnection()
+     * @see jakarta.jms.QueueConnectionFactory#createQueueConnection()
      */
     public QueueConnection createQueueConnection() throws JMSException {
         return createQueueConnection(getUsername(), getPassword());
@@ -155,7 +155,7 @@ public class StompJmsConnectionFactory extends JNDIStorable implements Connectio
      * @param password
      * @return a QueueConnection
      * @throws JMSException
-     * @see javax.jms.QueueConnectionFactory#createQueueConnection(java.lang.String, java.lang.String)
+     * @see jakarta.jms.QueueConnectionFactory#createQueueConnection(java.lang.String, java.lang.String)
      */
     public QueueConnection createQueueConnection(String userName, String password) throws JMSException {
         try {
@@ -315,5 +315,24 @@ public class StompJmsConnectionFactory extends JNDIStorable implements Connectio
 
     public void setSslContext(SSLContext sslContext) {
         this.sslContext = sslContext;
+    }
+
+    /*
+     * New Methods from switching to jakarta.jms.
+     */
+    public JMSContext createContext() {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public JMSContext createContext(int i) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public JMSContext createContext(String s1, String s2) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public JMSContext createContext(String s1, String s2, int i) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
     }
 }

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsConnectionMetaData.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsConnectionMetaData.java
@@ -10,7 +10,7 @@
 
 package org.fusesource.stomp.jms;
 
-import javax.jms.ConnectionMetaData;
+import jakarta.jms.ConnectionMetaData;
 import java.util.Enumeration;
 import java.util.Vector;
 import java.util.regex.Matcher;

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsDestination.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsDestination.java
@@ -14,8 +14,8 @@ import org.fusesource.hawtbuf.AsciiBuffer;
 import org.fusesource.stomp.codec.StompFrame;
 import org.fusesource.stomp.jms.jndi.JNDIStorable;
 
-import javax.jms.InvalidDestinationException;
-import javax.jms.JMSException;
+import jakarta.jms.InvalidDestinationException;
+import jakarta.jms.JMSException;
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -26,7 +26,7 @@ import java.util.Map;
 /**
  * Jms Destination
  */
-public class StompJmsDestination extends JNDIStorable implements Externalizable, javax.jms.Destination,
+public class StompJmsDestination extends JNDIStorable implements Externalizable, jakarta.jms.Destination,
         Comparable<StompJmsDestination> {
 
     protected transient String prefix;

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsDurableTopicSubscriber.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsDurableTopicSubscriber.java
@@ -12,7 +12,7 @@ package org.fusesource.stomp.jms;
 
 import org.fusesource.hawtbuf.AsciiBuffer;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 /**
  * Implementation of a TopicSubscriber

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsExceptionSupport.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsExceptionSupport.java
@@ -10,9 +10,9 @@
 
 package org.fusesource.stomp.jms;
 
-import javax.jms.JMSException;
-import javax.jms.MessageEOFException;
-import javax.jms.MessageFormatException;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageEOFException;
+import jakarta.jms.MessageFormatException;
 
 /**
  * Create those nice, old fashioned JMS Exceptions

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsMessageConsumer.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsMessageConsumer.java
@@ -19,8 +19,8 @@ import org.fusesource.stomp.client.Promise;
 import org.fusesource.stomp.codec.StompFrame;
 import org.fusesource.stomp.jms.message.StompJmsMessage;
 
-import javax.jms.IllegalStateException;
-import javax.jms.*;
+import jakarta.jms.IllegalStateException;
+import jakarta.jms.*;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -78,7 +78,7 @@ public class StompJmsMessageConsumer implements MessageConsumer, StompJmsMessage
 
     /**
      * @throws JMSException
-     * @see javax.jms.MessageConsumer#close()
+     * @see jakarta.jms.MessageConsumer#close()
      */
     public void close() throws JMSException {
         if(closed.compareAndSet(false, true)) {
@@ -98,7 +98,7 @@ public class StompJmsMessageConsumer implements MessageConsumer, StompJmsMessage
     /**
      * @return the Message Selector
      * @throws JMSException
-     * @see javax.jms.MessageConsumer#getMessageSelector()
+     * @see jakarta.jms.MessageConsumer#getMessageSelector()
      */
     public String getMessageSelector() throws JMSException {
         checkClosed();
@@ -108,7 +108,7 @@ public class StompJmsMessageConsumer implements MessageConsumer, StompJmsMessage
     /**
      * @return a Message or null if closed during the operation
      * @throws JMSException
-     * @see javax.jms.MessageConsumer#receive()
+     * @see jakarta.jms.MessageConsumer#receive()
      */
     public Message receive() throws JMSException {
         checkClosed();
@@ -123,7 +123,7 @@ public class StompJmsMessageConsumer implements MessageConsumer, StompJmsMessage
      * @param timeout
      * @return a MEssage or null
      * @throws JMSException
-     * @see javax.jms.MessageConsumer#receive(long)
+     * @see jakarta.jms.MessageConsumer#receive(long)
      */
     public Message receive(long timeout) throws JMSException {
         checkClosed();
@@ -137,7 +137,7 @@ public class StompJmsMessageConsumer implements MessageConsumer, StompJmsMessage
     /**
      * @return a Message or null
      * @throws JMSException
-     * @see javax.jms.MessageConsumer#receiveNoWait()
+     * @see jakarta.jms.MessageConsumer#receiveNoWait()
      */
     public Message receiveNoWait() throws JMSException {
         checkClosed();
@@ -148,7 +148,7 @@ public class StompJmsMessageConsumer implements MessageConsumer, StompJmsMessage
     /**
      * @param listener
      * @throws JMSException
-     * @see javax.jms.MessageConsumer#setMessageListener(javax.jms.MessageListener)
+     * @see jakarta.jms.MessageConsumer#setMessageListener(jakarta.jms.MessageListener)
      */
     public void setMessageListener(MessageListener listener) throws JMSException {
         checkClosed();
@@ -248,7 +248,7 @@ public class StompJmsMessageConsumer implements MessageConsumer, StompJmsMessage
                 message.setAcknowledgeCallback(new Callable<Void>(){
                     public Void call() throws Exception {
                         if( session.channel == null ) {
-                            throw new javax.jms.IllegalStateException("Session closed.");
+                            throw new jakarta.jms.IllegalStateException("Session closed.");
                         }
                         doAck(message);
                         return null;

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsMessageProducer.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsMessageProducer.java
@@ -12,8 +12,8 @@ package org.fusesource.stomp.jms;
 
 import org.fusesource.stomp.jms.message.StompJmsMessageTransformation;
 
-import javax.jms.*;
-import javax.jms.IllegalStateException;
+import jakarta.jms.*;
+import jakarta.jms.IllegalStateException;
 
 /**
  * Implementation of a Jms MessageProducer
@@ -38,7 +38,7 @@ public class StompJmsMessageProducer implements MessageProducer {
     /**
      * Close the producer
      *
-     * @see javax.jms.MessageProducer#close()
+     * @see jakarta.jms.MessageProducer#close()
      */
     public void close() {
         this.closed = true;
@@ -48,7 +48,7 @@ public class StompJmsMessageProducer implements MessageProducer {
     /**
      * @return the delivery mode
      * @throws JMSException
-     * @see javax.jms.MessageProducer#getDeliveryMode()
+     * @see jakarta.jms.MessageProducer#getDeliveryMode()
      */
     public int getDeliveryMode() throws JMSException {
         checkClosed();
@@ -58,7 +58,7 @@ public class StompJmsMessageProducer implements MessageProducer {
     /**
      * @return the destination
      * @throws JMSException
-     * @see javax.jms.MessageProducer#getDestination()
+     * @see jakarta.jms.MessageProducer#getDestination()
      */
     public Destination getDestination() throws JMSException {
         checkClosed();
@@ -68,7 +68,7 @@ public class StompJmsMessageProducer implements MessageProducer {
     /**
      * @return true if disableIds is set
      * @throws JMSException
-     * @see javax.jms.MessageProducer#getDisableMessageID()
+     * @see jakarta.jms.MessageProducer#getDisableMessageID()
      */
     public boolean getDisableMessageID() throws JMSException {
         checkClosed();
@@ -78,7 +78,7 @@ public class StompJmsMessageProducer implements MessageProducer {
     /**
      * @return true if disable timestamp is set
      * @throws JMSException
-     * @see javax.jms.MessageProducer#getDisableMessageTimestamp()
+     * @see jakarta.jms.MessageProducer#getDisableMessageTimestamp()
      */
     public boolean getDisableMessageTimestamp() throws JMSException {
         checkClosed();
@@ -88,7 +88,7 @@ public class StompJmsMessageProducer implements MessageProducer {
     /**
      * @return the priority
      * @throws JMSException
-     * @see javax.jms.MessageProducer#getPriority()
+     * @see jakarta.jms.MessageProducer#getPriority()
      */
     public int getPriority() throws JMSException {
         checkClosed();
@@ -98,7 +98,7 @@ public class StompJmsMessageProducer implements MessageProducer {
     /**
      * @return timeToLive
      * @throws JMSException
-     * @see javax.jms.MessageProducer#getTimeToLive()
+     * @see jakarta.jms.MessageProducer#getTimeToLive()
      */
     public long getTimeToLive() throws JMSException {
         checkClosed();
@@ -108,7 +108,7 @@ public class StompJmsMessageProducer implements MessageProducer {
     /**
      * @param message
      * @throws JMSException
-     * @see javax.jms.MessageProducer#send(javax.jms.Message)
+     * @see jakarta.jms.MessageProducer#send(jakarta.jms.Message)
      */
     public void send(Message message) throws JMSException {
         send(this.destination, message, this.deliveryMode, this.priority, this.timeToLive);
@@ -118,7 +118,7 @@ public class StompJmsMessageProducer implements MessageProducer {
      * @param destination
      * @param message
      * @throws JMSException
-     * @see javax.jms.MessageProducer#send(javax.jms.Destination, javax.jms.Message)
+     * @see jakarta.jms.MessageProducer#send(jakarta.jms.Destination, jakarta.jms.Message)
      */
     public void send(Destination destination, Message message) throws JMSException {
         send(destination, message, this.deliveryMode, this.priority, this.timeToLive);
@@ -130,7 +130,7 @@ public class StompJmsMessageProducer implements MessageProducer {
      * @param priority
      * @param timeToLive
      * @throws JMSException
-     * @see javax.jms.MessageProducer#send(javax.jms.Message, int, int, long)
+     * @see jakarta.jms.MessageProducer#send(jakarta.jms.Message, int, int, long)
      */
     public void send(Message message, int deliveryMode, int priority, long timeToLive) throws JMSException {
         send(this.destination, message, deliveryMode, priority, timeToLive);
@@ -143,7 +143,7 @@ public class StompJmsMessageProducer implements MessageProducer {
      * @param priority
      * @param timeToLive
      * @throws JMSException
-     * @see javax.jms.MessageProducer#send(javax.jms.Destination, javax.jms.Message, int, int, long)
+     * @see jakarta.jms.MessageProducer#send(jakarta.jms.Destination, jakarta.jms.Message, int, int, long)
      */
     public void send(Destination destination, Message message, int deliveryMode, int priority, long timeToLive)
             throws JMSException {
@@ -160,7 +160,7 @@ public class StompJmsMessageProducer implements MessageProducer {
     /**
      * @param deliveryMode
      * @throws JMSException
-     * @see javax.jms.MessageProducer#setDeliveryMode(int)
+     * @see jakarta.jms.MessageProducer#setDeliveryMode(int)
      */
     public void setDeliveryMode(int deliveryMode) throws JMSException {
         checkClosed();
@@ -170,7 +170,7 @@ public class StompJmsMessageProducer implements MessageProducer {
     /**
      * @param value
      * @throws JMSException
-     * @see javax.jms.MessageProducer#setDisableMessageID(boolean)
+     * @see jakarta.jms.MessageProducer#setDisableMessageID(boolean)
      */
     public void setDisableMessageID(boolean value) throws JMSException {
         checkClosed();
@@ -180,7 +180,7 @@ public class StompJmsMessageProducer implements MessageProducer {
     /**
      * @param value
      * @throws JMSException
-     * @see javax.jms.MessageProducer#setDisableMessageTimestamp(boolean)
+     * @see jakarta.jms.MessageProducer#setDisableMessageTimestamp(boolean)
      */
     public void setDisableMessageTimestamp(boolean value) throws JMSException {
         checkClosed();
@@ -190,7 +190,7 @@ public class StompJmsMessageProducer implements MessageProducer {
     /**
      * @param defaultPriority
      * @throws JMSException
-     * @see javax.jms.MessageProducer#setPriority(int)
+     * @see jakarta.jms.MessageProducer#setPriority(int)
      */
     public void setPriority(int defaultPriority) throws JMSException {
         checkClosed();
@@ -200,7 +200,7 @@ public class StompJmsMessageProducer implements MessageProducer {
     /**
      * @param timeToLive
      * @throws JMSException
-     * @see javax.jms.MessageProducer#setTimeToLive(long)
+     * @see jakarta.jms.MessageProducer#setTimeToLive(long)
      */
     public void setTimeToLive(long timeToLive) throws JMSException {
         checkClosed();
@@ -227,5 +227,32 @@ public class StompJmsMessageProducer implements MessageProducer {
         if (this.closed) {
             throw new IllegalStateException("The MessageProducer is closed");
         }
+    }
+
+    /*
+     * New Methods from switching to jakarta.jms.
+     */
+    public long getDeliveryDelay() {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public void setDeliveryDelay(long l) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public void send(Message m, CompletionListener cl) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public void send(Destination d, Message m, CompletionListener cl) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public void send(Message m, int i1, int i2, long l, CompletionListener cl) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public void send(Destination d, Message m, int i1, int i2, long l, CompletionListener cl) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
     }
 }

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsQueue.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsQueue.java
@@ -10,7 +10,7 @@
 
 package org.fusesource.stomp.jms;
 
-import javax.jms.Queue;
+import jakarta.jms.Queue;
 
 /**
  * Queue implementation
@@ -42,7 +42,7 @@ public class StompJmsQueue extends StompJmsDestination implements Queue {
 
     /**
      * @return name
-     * @see javax.jms.Queue#getQueueName()
+     * @see jakarta.jms.Queue#getQueueName()
      */
     public String getQueueName() {
         return getName();

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsQueueBrowser.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsQueueBrowser.java
@@ -13,8 +13,8 @@ package org.fusesource.stomp.jms;
 import org.fusesource.hawtbuf.AsciiBuffer;
 import org.fusesource.stomp.jms.message.StompJmsMessage;
 
-import javax.jms.IllegalStateException;
-import javax.jms.*;
+import jakarta.jms.IllegalStateException;
+import jakarta.jms.*;
 import java.util.Enumeration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import static org.fusesource.stomp.client.Constants.*;
@@ -38,10 +38,10 @@ import static org.fusesource.stomp.client.Constants.*;
  * </CODE>
  * or a <CODE>QueueSession</CODE>.
  *
- * @see javax.jms.Session#createBrowser
- * @see javax.jms.QueueSession#createBrowser
- * @see javax.jms.QueueBrowser
- * @see javax.jms.QueueReceiver
+ * @see jakarta.jms.Session#createBrowser
+ * @see jakarta.jms.QueueSession#createBrowser
+ * @see jakarta.jms.QueueBrowser
+ * @see jakarta.jms.QueueReceiver
  */
 
 public class StompJmsQueueBrowser implements QueueBrowser, Enumeration {
@@ -63,7 +63,7 @@ public class StompJmsQueueBrowser implements QueueBrowser, Enumeration {
      * @param id
      * @param destination
      * @param selector
-     * @throws javax.jms.JMSException
+     * @throws jakarta.jms.JMSException
      */
     protected StompJmsQueueBrowser(StompJmsSession session, AsciiBuffer id, StompJmsDestination destination, String selector) throws JMSException {
         this.session = session;
@@ -121,7 +121,7 @@ public class StompJmsQueueBrowser implements QueueBrowser, Enumeration {
      * they would be received.
      *
      * @return an enumeration for browsing the messages
-     * @throws javax.jms.JMSException if the JMS provider fails to get the enumeration for
+     * @throws jakarta.jms.JMSException if the JMS provider fails to get the enumeration for
      *                                this browser due to some internal error.
      */
 
@@ -204,7 +204,7 @@ public class StompJmsQueueBrowser implements QueueBrowser, Enumeration {
      * Gets the queue associated with this queue browser.
      *
      * @return the queue
-     * @throws javax.jms.JMSException if the JMS provider fails to get the queue
+     * @throws jakarta.jms.JMSException if the JMS provider fails to get the queue
      *                                associated with this browser due to some internal error.
      */
 

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsQueueConnection.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsQueueConnection.java
@@ -9,7 +9,7 @@
  */
 package org.fusesource.stomp.jms;
 
-import javax.jms.*;
+import jakarta.jms.*;
 import javax.net.ssl.SSLContext;
 import java.net.URI;
 
@@ -24,17 +24,17 @@ public class StompJmsQueueConnection extends StompJmsConnection {
 
     @Override
     public TopicSession createTopicSession(boolean transacted, int acknowledgeMode) throws JMSException {
-        throw new javax.jms.IllegalStateException("Operation not supported by a QueueConnection");
+        throw new jakarta.jms.IllegalStateException("Operation not supported by a QueueConnection");
     }
 
     @Override
     public ConnectionConsumer createDurableConnectionConsumer(Topic topic, String subscriptionName, String messageSelector, ServerSessionPool sessionPool, int maxMessages) throws JMSException {
-        throw new javax.jms.IllegalStateException("Operation not supported by a QueueConnection");
+        throw new jakarta.jms.IllegalStateException("Operation not supported by a QueueConnection");
     }
 
     @Override
     public ConnectionConsumer createConnectionConsumer(Topic topic, String messageSelector, ServerSessionPool sessionPool, int maxMessages) throws JMSException {
-        throw new javax.jms.IllegalStateException("Operation not supported by a QueueConnection");
+        throw new jakarta.jms.IllegalStateException("Operation not supported by a QueueConnection");
     }
 
 }

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsQueueReceiver.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsQueueReceiver.java
@@ -12,10 +12,10 @@ package org.fusesource.stomp.jms;
 
 import org.fusesource.hawtbuf.AsciiBuffer;
 
-import javax.jms.IllegalStateException;
-import javax.jms.JMSException;
-import javax.jms.Queue;
-import javax.jms.QueueReceiver;
+import jakarta.jms.IllegalStateException;
+import jakarta.jms.JMSException;
+import jakarta.jms.Queue;
+import jakarta.jms.QueueReceiver;
 
 /**
  * Implementation of a Jms QueueReceiver
@@ -34,7 +34,7 @@ public class StompJmsQueueReceiver extends StompJmsMessageConsumer implements Qu
     /**
      * @return the Queue
      * @throws IllegalStateException
-     * @see javax.jms.QueueReceiver#getQueue()
+     * @see jakarta.jms.QueueReceiver#getQueue()
      */
     public Queue getQueue() throws IllegalStateException {
         checkClosed();

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsQueueSender.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsQueueSender.java
@@ -10,8 +10,8 @@
 
 package org.fusesource.stomp.jms;
 
-import javax.jms.IllegalStateException;
-import javax.jms.*;
+import jakarta.jms.IllegalStateException;
+import jakarta.jms.*;
 
 /**
  * Implementation of a Queue Sender
@@ -30,7 +30,7 @@ public class StompJmsQueueSender extends StompJmsMessageProducer implements Queu
     /**
      * @return the Queue
      * @throws IllegalStateException
-     * @see javax.jms.QueueSender#getQueue()
+     * @see jakarta.jms.QueueSender#getQueue()
      */
     public Queue getQueue() throws IllegalStateException {
         checkClosed();
@@ -41,7 +41,7 @@ public class StompJmsQueueSender extends StompJmsMessageProducer implements Queu
      * @param queue
      * @param message
      * @throws JMSException
-     * @see javax.jms.QueueSender#send(javax.jms.Queue, javax.jms.Message)
+     * @see jakarta.jms.QueueSender#send(jakarta.jms.Queue, jakarta.jms.Message)
      */
     public void send(Queue queue, Message message) throws JMSException {
         super.send(queue, message);
@@ -54,7 +54,7 @@ public class StompJmsQueueSender extends StompJmsMessageProducer implements Queu
      * @param priority
      * @param timeToLive
      * @throws JMSException
-     * @see javax.jms.QueueSender#send(javax.jms.Queue, javax.jms.Message, int, int, long)
+     * @see jakarta.jms.QueueSender#send(jakarta.jms.Queue, jakarta.jms.Message, int, int, long)
      */
     public void send(Queue queue, Message message, int deliveryMode, int priority, long timeToLive) throws JMSException {
         super.send(message, deliveryMode, priority, timeToLive);

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsQueueSession.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsQueueSession.java
@@ -10,8 +10,8 @@
 
 package org.fusesource.stomp.jms;
 
-import javax.jms.*;
-import javax.jms.IllegalStateException;
+import jakarta.jms.*;
+import jakarta.jms.IllegalStateException;
 
 
 /**
@@ -40,7 +40,7 @@ public class StompJmsQueueSession extends StompJmsSession {
      * @param messageSelector
      * @return
      * @throws JMSException
-     * @see javax.jms.Session#createConsumer(javax.jms.Destination, java.lang.String)
+     * @see jakarta.jms.Session#createConsumer(jakarta.jms.Destination, java.lang.String)
      */
     public MessageConsumer createConsumer(Destination destination, String messageSelector) throws JMSException {
         if (destination instanceof Topic) {
@@ -55,7 +55,7 @@ public class StompJmsQueueSession extends StompJmsSession {
      * @param NoLocal
      * @return
      * @throws JMSException
-     * @see javax.jms.Session#createConsumer(javax.jms.Destination, java.lang.String, boolean)
+     * @see jakarta.jms.Session#createConsumer(jakarta.jms.Destination, java.lang.String, boolean)
      */
     public MessageConsumer createConsumer(Destination destination, String messageSelector, boolean NoLocal)
             throws JMSException {
@@ -67,7 +67,7 @@ public class StompJmsQueueSession extends StompJmsSession {
      * @param name
      * @return
      * @throws JMSException
-     * @see javax.jms.Session#createDurableSubscriber(javax.jms.Topic, java.lang.String)
+     * @see jakarta.jms.Session#createDurableSubscriber(jakarta.jms.Topic, java.lang.String)
      */
     public TopicSubscriber createDurableSubscriber(Topic topic, String name) throws JMSException {
         throw new IllegalStateException("Operation not supported by a QueueSession");
@@ -81,7 +81,7 @@ public class StompJmsQueueSession extends StompJmsSession {
      * @return
      * @throws IllegalStateException
      * @throws JMSException
-     * @see javax.jms.Session#createDurableSubscriber(javax.jms.Topic, java.lang.String, java.lang.String, boolean)
+     * @see jakarta.jms.Session#createDurableSubscriber(jakarta.jms.Topic, java.lang.String, java.lang.String, boolean)
      */
     public TopicSubscriber createDurableSubscriber(Topic topic, String name, String messageSelector, boolean noLocal)
             throws IllegalStateException {
@@ -92,7 +92,7 @@ public class StompJmsQueueSession extends StompJmsSession {
      * @param destination
      * @return
      * @throws JMSException
-     * @see javax.jms.Session#createProducer(javax.jms.Destination)
+     * @see jakarta.jms.Session#createProducer(jakarta.jms.Destination)
      */
     public MessageProducer createProducer(Destination destination) throws JMSException {
         if (destination instanceof Topic) {
@@ -104,7 +104,7 @@ public class StompJmsQueueSession extends StompJmsSession {
     /**
      * @return
      * @throws JMSException
-     * @see javax.jms.Session#createTemporaryTopic()
+     * @see jakarta.jms.Session#createTemporaryTopic()
      */
     public TemporaryTopic createTemporaryTopic() throws JMSException {
         throw new IllegalStateException("Operation not supported by a QueueSession");
@@ -114,7 +114,7 @@ public class StompJmsQueueSession extends StompJmsSession {
      * @param topicName
      * @return
      * @throws JMSException
-     * @see javax.jms.Session#createTopic(java.lang.String)
+     * @see jakarta.jms.Session#createTopic(java.lang.String)
      */
     public Topic createTopic(String topicName) throws JMSException {
         throw new IllegalStateException("Operation not supported by a QueueSession");
@@ -123,7 +123,7 @@ public class StompJmsQueueSession extends StompJmsSession {
     /**
      * @param name
      * @throws JMSException
-     * @see javax.jms.Session#unsubscribe(java.lang.String)
+     * @see jakarta.jms.Session#unsubscribe(java.lang.String)
      */
     public void unsubscribe(String name) throws JMSException {
         throw new IllegalStateException("Operation not supported by a QueueSession");
@@ -133,7 +133,7 @@ public class StompJmsQueueSession extends StompJmsSession {
      * @param topic
      * @return
      * @throws JMSException
-     * @see javax.jms.TopicSession#createPublisher(javax.jms.Topic)
+     * @see jakarta.jms.TopicSession#createPublisher(jakarta.jms.Topic)
      */
     public TopicPublisher createPublisher(Topic topic) throws JMSException {
         throw new IllegalStateException("Operation not supported by a QueueSession");
@@ -143,7 +143,7 @@ public class StompJmsQueueSession extends StompJmsSession {
      * @param topic
      * @return
      * @throws JMSException
-     * @see javax.jms.TopicSession#createSubscriber(javax.jms.Topic)
+     * @see jakarta.jms.TopicSession#createSubscriber(jakarta.jms.Topic)
      */
     public TopicSubscriber createSubscriber(Topic topic) throws JMSException {
         throw new IllegalStateException("Operation not supported by a QueueSession");
@@ -155,7 +155,7 @@ public class StompJmsQueueSession extends StompJmsSession {
      * @param noLocal
      * @return
      * @throws JMSException
-     * @see javax.jms.TopicSession#createSubscriber(javax.jms.Topic, java.lang.String, boolean)
+     * @see jakarta.jms.TopicSession#createSubscriber(jakarta.jms.Topic, java.lang.String, boolean)
      */
     public TopicSubscriber createSubscriber(Topic topic, String messageSelector, boolean noLocal) throws JMSException {
         throw new IllegalStateException("Operation not supported by a QueueSession");

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsSession.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsSession.java
@@ -17,8 +17,8 @@ import org.fusesource.hawtbuf.ByteArrayOutputStream;
 import org.fusesource.stomp.codec.StompFrame;
 import org.fusesource.stomp.jms.message.*;
 
-import javax.jms.*;
-import javax.jms.IllegalStateException;
+import jakarta.jms.*;
+import jakarta.jms.IllegalStateException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -74,7 +74,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
     /**
      * @return acknowledgeMode
      * @throws JMSException
-     * @see javax.jms.Session#getAcknowledgeMode()
+     * @see jakarta.jms.Session#getAcknowledgeMode()
      */
     public int getAcknowledgeMode() throws JMSException {
         checkClosed();
@@ -84,7 +84,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
     /**
      * @return true if transacted
      * @throws JMSException
-     * @see javax.jms.Session#getTransacted()
+     * @see jakarta.jms.Session#getTransacted()
      */
     public boolean getTransacted() throws JMSException {
         checkClosed();
@@ -94,7 +94,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
     /**
      * @return the Sesion messageListener
      * @throws JMSException
-     * @see javax.jms.Session#getMessageListener()
+     * @see jakarta.jms.Session#getMessageListener()
      */
     public MessageListener getMessageListener() throws JMSException {
         checkClosed();
@@ -104,7 +104,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
     /**
      * @param listener
      * @throws JMSException
-     * @see javax.jms.Session#setMessageListener(javax.jms.MessageListener)
+     * @see jakarta.jms.Session#setMessageListener(jakarta.jms.MessageListener)
      */
     public void setMessageListener(MessageListener listener) throws JMSException {
         checkClosed();
@@ -113,24 +113,24 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
 
     /**
      * @throws JMSException
-     * @see javax.jms.Session#recover()
+     * @see jakarta.jms.Session#recover()
      */
     public void recover() throws JMSException {
         checkClosed();
         if (getTransacted()) {
-            throw new javax.jms.IllegalStateException("Cannot call recover() on a transacted session");
+            throw new jakarta.jms.IllegalStateException("Cannot call recover() on a transacted session");
         }
         // TODO: re-deliver all un-acked client-ack messages.
     }
 
     /**
      * @throws JMSException
-     * @see javax.jms.Session#commit()
+     * @see jakarta.jms.Session#commit()
      */
     public void commit() throws JMSException {
         checkClosed();
         if (!getTransacted()) {
-            throw new javax.jms.IllegalStateException("Not a transacted session");
+            throw new jakarta.jms.IllegalStateException("Not a transacted session");
         }
         for (StompJmsMessageConsumer c : consumers.values()) {
             c.commit();
@@ -141,12 +141,12 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
 
     /**
      * @throws JMSException
-     * @see javax.jms.Session#rollback()
+     * @see jakarta.jms.Session#rollback()
      */
     public void rollback() throws JMSException {
         checkClosed();
         if (!getTransacted()) {
-            throw new javax.jms.IllegalStateException("Not a transacted session");
+            throw new jakarta.jms.IllegalStateException("Not a transacted session");
         }
         for (StompJmsMessageConsumer c : consumers.values()) {
             c.rollback();
@@ -163,7 +163,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
     }
 
     /**
-     * @see javax.jms.Session#run()
+     * @see jakarta.jms.Session#run()
      */
     public void run() {
         // TODO Auto-generated method stub
@@ -171,7 +171,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
 
     /**
      * @throws JMSException
-     * @see javax.jms.Session#close()
+     * @see jakarta.jms.Session#close()
      */
     public void close() throws JMSException {
         if (closed.compareAndSet(false, true)) {
@@ -194,7 +194,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param destination
      * @return a MessageConsumer
      * @throws JMSException
-     * @see javax.jms.Session#createConsumer(javax.jms.Destination)
+     * @see jakarta.jms.Session#createConsumer(jakarta.jms.Destination)
      */
     public MessageConsumer createConsumer(Destination destination) throws JMSException {
         checkClosed();
@@ -210,7 +210,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param messageSelector
      * @return MessageConsumer
      * @throws JMSException
-     * @see javax.jms.Session#createConsumer(javax.jms.Destination,
+     * @see jakarta.jms.Session#createConsumer(jakarta.jms.Destination,
      *      java.lang.String)
      */
     public MessageConsumer createConsumer(Destination destination, String messageSelector) throws JMSException {
@@ -230,7 +230,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param NoLocal
      * @return the MessageConsumer
      * @throws JMSException
-     * @see javax.jms.Session#createConsumer(javax.jms.Destination,
+     * @see jakarta.jms.Session#createConsumer(jakarta.jms.Destination,
      *      java.lang.String, boolean)
      */
     public MessageConsumer createConsumer(Destination destination, String messageSelector, boolean NoLocal)
@@ -249,7 +249,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param queue
      * @return QueueRecevier
      * @throws JMSException
-     * @see javax.jms.QueueSession#createReceiver(javax.jms.Queue)
+     * @see jakarta.jms.QueueSession#createReceiver(jakarta.jms.Queue)
      */
     public QueueReceiver createReceiver(Queue queue) throws JMSException {
         checkClosed();
@@ -265,7 +265,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param messageSelector
      * @return QueueReceiver
      * @throws JMSException
-     * @see javax.jms.QueueSession#createReceiver(javax.jms.Queue,
+     * @see jakarta.jms.QueueSession#createReceiver(jakarta.jms.Queue,
      *      java.lang.String)
      */
     public QueueReceiver createReceiver(Queue queue, String messageSelector) throws JMSException {
@@ -282,7 +282,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param destination
      * @return QueueBrowser
      * @throws JMSException
-     * @see javax.jms.Session#createBrowser(javax.jms.Queue)
+     * @see jakarta.jms.Session#createBrowser(jakarta.jms.Queue)
      */
     public QueueBrowser createBrowser(Queue destination) throws JMSException {
         checkClosed();
@@ -297,7 +297,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param messageSelector
      * @return QueueBrowser
      * @throws JMSException
-     * @see javax.jms.Session#createBrowser(javax.jms.Queue, java.lang.String)
+     * @see jakarta.jms.Session#createBrowser(jakarta.jms.Queue, java.lang.String)
      */
     public QueueBrowser createBrowser(Queue destination, String messageSelector) throws JMSException {
         checkClosed();
@@ -312,7 +312,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param topic
      * @return TopicSubscriber
      * @throws JMSException
-     * @see javax.jms.TopicSession#createSubscriber(javax.jms.Topic)
+     * @see jakarta.jms.TopicSession#createSubscriber(jakarta.jms.Topic)
      */
     public TopicSubscriber createSubscriber(Topic topic) throws JMSException {
         checkClosed();
@@ -329,7 +329,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param noLocal
      * @return TopicSubscriber
      * @throws JMSException
-     * @see javax.jms.TopicSession#createSubscriber(javax.jms.Topic,
+     * @see jakarta.jms.TopicSession#createSubscriber(jakarta.jms.Topic,
      *      java.lang.String, boolean)
      */
     public TopicSubscriber createSubscriber(Topic topic, String messageSelector, boolean noLocal) throws JMSException {
@@ -346,7 +346,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param name
      * @return a TopicSubscriber
      * @throws JMSException
-     * @see javax.jms.Session#createDurableSubscriber(javax.jms.Topic,
+     * @see jakarta.jms.Session#createDurableSubscriber(jakarta.jms.Topic,
      *      java.lang.String)
      */
     public TopicSubscriber createDurableSubscriber(Topic topic, String name) throws JMSException {
@@ -366,7 +366,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param noLocal
      * @return TopicSubscriber
      * @throws JMSException
-     * @see javax.jms.Session#createDurableSubscriber(javax.jms.Topic,
+     * @see jakarta.jms.Session#createDurableSubscriber(jakarta.jms.Topic,
      *      java.lang.String, java.lang.String, boolean)
      */
     public TopicSubscriber createDurableSubscriber(Topic topic, String name, String messageSelector, boolean noLocal)
@@ -389,7 +389,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
     /**
      * @param name
      * @throws JMSException
-     * @see javax.jms.Session#unsubscribe(java.lang.String)
+     * @see jakarta.jms.Session#unsubscribe(java.lang.String)
      */
     public void unsubscribe(String name) throws JMSException {
         checkClosed();
@@ -411,7 +411,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param destination
      * @return MessageProducer
      * @throws JMSException
-     * @see javax.jms.Session#createProducer(javax.jms.Destination)
+     * @see jakarta.jms.Session#createProducer(jakarta.jms.Destination)
      */
     public MessageProducer createProducer(Destination destination) throws JMSException {
         checkClosed();
@@ -425,7 +425,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param queue
      * @return QueueSender
      * @throws JMSException
-     * @see javax.jms.QueueSession#createSender(javax.jms.Queue)
+     * @see jakarta.jms.QueueSession#createSender(jakarta.jms.Queue)
      */
     public QueueSender createSender(Queue queue) throws JMSException {
         checkClosed();
@@ -438,7 +438,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param topic
      * @return TopicPublisher
      * @throws JMSException
-     * @see javax.jms.TopicSession#createPublisher(javax.jms.Topic)
+     * @see jakarta.jms.TopicSession#createPublisher(jakarta.jms.Topic)
      */
     public TopicPublisher createPublisher(Topic topic) throws JMSException {
         checkClosed();
@@ -457,7 +457,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
     /**
      * @return BytesMessage
      * @throws IllegalStateException
-     * @see javax.jms.Session#createBytesMessage()
+     * @see jakarta.jms.Session#createBytesMessage()
      */
     public BytesMessage createBytesMessage() throws IllegalStateException {
         checkClosed();
@@ -467,7 +467,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
     /**
      * @return MapMessage
      * @throws IllegalStateException
-     * @see javax.jms.Session#createMapMessage()
+     * @see jakarta.jms.Session#createMapMessage()
      */
     public MapMessage createMapMessage() throws IllegalStateException {
         checkClosed();
@@ -477,7 +477,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
     /**
      * @return Message
      * @throws IllegalStateException
-     * @see javax.jms.Session#createMessage()
+     * @see jakarta.jms.Session#createMessage()
      */
     public Message createMessage() throws IllegalStateException {
         checkClosed();
@@ -487,7 +487,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
     /**
      * @return ObjectMessage
      * @throws IllegalStateException
-     * @see javax.jms.Session#createObjectMessage()
+     * @see jakarta.jms.Session#createObjectMessage()
      */
     public ObjectMessage createObjectMessage() throws IllegalStateException {
         checkClosed();
@@ -498,7 +498,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param object
      * @return ObjectMessage
      * @throws JMSException
-     * @see javax.jms.Session#createObjectMessage(java.io.Serializable)
+     * @see jakarta.jms.Session#createObjectMessage(java.io.Serializable)
      */
     public ObjectMessage createObjectMessage(Serializable object) throws JMSException {
         ObjectMessage result = createObjectMessage();
@@ -509,7 +509,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
     /**
      * @return StreamMessage
      * @throws JMSException
-     * @see javax.jms.Session#createStreamMessage()
+     * @see jakarta.jms.Session#createStreamMessage()
      */
     public StreamMessage createStreamMessage() throws JMSException {
         checkClosed();
@@ -519,7 +519,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
     /**
      * @return TextMessage
      * @throws JMSException
-     * @see javax.jms.Session#createTextMessage()
+     * @see jakarta.jms.Session#createTextMessage()
      */
     public TextMessage createTextMessage() throws JMSException {
         checkClosed();
@@ -530,7 +530,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param text
      * @return TextMessage
      * @throws JMSException
-     * @see javax.jms.Session#createTextMessage(java.lang.String)
+     * @see jakarta.jms.Session#createTextMessage(java.lang.String)
      */
     public TextMessage createTextMessage(String text) throws JMSException {
         TextMessage result = createTextMessage();
@@ -548,7 +548,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param queueName
      * @return Queue
      * @throws JMSException
-     * @see javax.jms.Session#createQueue(java.lang.String)
+     * @see jakarta.jms.Session#createQueue(java.lang.String)
      */
     public Queue createQueue(String queueName) throws JMSException {
         checkClosed();
@@ -558,7 +558,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
     /**
      * @return TemporaryQueue
      * @throws JMSException
-     * @see javax.jms.Session#createTemporaryQueue()
+     * @see jakarta.jms.Session#createTemporaryQueue()
      */
     public TemporaryQueue createTemporaryQueue() throws JMSException {
         checkClosed();
@@ -568,7 +568,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
     /**
      * @return TemporaryTopic
      * @throws JMSException
-     * @see javax.jms.Session#createTemporaryTopic()
+     * @see jakarta.jms.Session#createTemporaryTopic()
      */
     public TemporaryTopic createTemporaryTopic() throws JMSException {
         checkClosed();
@@ -579,7 +579,7 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
      * @param topicName
      * @return Topic
      * @throws JMSException
-     * @see javax.jms.Session#createTopic(java.lang.String)
+     * @see jakarta.jms.Session#createTopic(java.lang.String)
      */
     public Topic createTopic(String topicName) throws JMSException {
         checkClosed();
@@ -871,5 +871,32 @@ public class StompJmsSession implements Session, QueueSession, TopicSession, Sto
 
     public void setPrefetch(StompJmsPrefetch prefetch) {
         this.prefetch = prefetch;
+    }
+
+    /*
+     * New Methods from switching to jakarta.jms.
+     */
+    public MessageConsumer createDurableConsumer(Topic t ,String s1) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public MessageConsumer createSharedConsumer(Topic t ,String s1) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public MessageConsumer createSharedConsumer(Topic t ,String s1, String s2) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public MessageConsumer createSharedDurableConsumer(Topic t ,String s1) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public MessageConsumer createSharedDurableConsumer(Topic t ,String s1, String s2) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public MessageConsumer createDurableConsumer(Topic t, String s1, String s2, boolean b) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
     }
 }

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsTempQueue.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsTempQueue.java
@@ -10,7 +10,7 @@
 
 package org.fusesource.stomp.jms;
 
-import javax.jms.TemporaryQueue;
+import jakarta.jms.TemporaryQueue;
 
 
 /**
@@ -33,7 +33,7 @@ public class StompJmsTempQueue extends StompJmsDestination implements TemporaryQ
     }
 
     /**
-     * @see javax.jms.TemporaryQueue#delete()
+     * @see jakarta.jms.TemporaryQueue#delete()
      */
     public void delete() {
         // TODO: stomp does not really have a way to delete destinations.. :(
@@ -41,7 +41,7 @@ public class StompJmsTempQueue extends StompJmsDestination implements TemporaryQ
 
     /**
      * @return name
-     * @see javax.jms.Queue#getQueueName()
+     * @see jakarta.jms.Queue#getQueueName()
      */
     public String getQueueName() {
         return getName();

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsTempTopic.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsTempTopic.java
@@ -10,7 +10,7 @@
 
 package org.fusesource.stomp.jms;
 
-import javax.jms.TemporaryTopic;
+import jakarta.jms.TemporaryTopic;
 
 
 /**
@@ -32,7 +32,7 @@ public class StompJmsTempTopic extends StompJmsDestination implements TemporaryT
     }
 
     /**
-     * @see javax.jms.TemporaryTopic#delete()
+     * @see jakarta.jms.TemporaryTopic#delete()
      */
     public void delete() {
         // TODO: stomp does not really have a way to delete destinations.. :(
@@ -40,7 +40,7 @@ public class StompJmsTempTopic extends StompJmsDestination implements TemporaryT
 
     /**
      * @return name
-     * @see javax.jms.Topic#getTopicName()
+     * @see jakarta.jms.Topic#getTopicName()
      */
     public String getTopicName() {
         return getName();

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsTopic.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsTopic.java
@@ -10,7 +10,7 @@
 
 package org.fusesource.stomp.jms;
 
-import javax.jms.Topic;
+import jakarta.jms.Topic;
 
 /**
  * TemporaryQueue
@@ -44,7 +44,7 @@ public class StompJmsTopic extends StompJmsDestination implements Topic {
 
     /**
      * @return the name
-     * @see javax.jms.Topic#getTopicName()
+     * @see jakarta.jms.Topic#getTopicName()
      */
     public String getTopicName() {
         return getName();

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsTopicConnection.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsTopicConnection.java
@@ -9,7 +9,7 @@
  */
 package org.fusesource.stomp.jms;
 
-import javax.jms.*;
+import jakarta.jms.*;
 import javax.net.ssl.SSLContext;
 import java.net.URI;
 
@@ -24,12 +24,12 @@ public class StompJmsTopicConnection extends StompJmsConnection {
 
     @Override
     public ConnectionConsumer createConnectionConsumer(Queue queue, String messageSelector, ServerSessionPool sessionPool, int maxMessages) throws JMSException {
-        throw new javax.jms.IllegalStateException("Operation not supported by a TopicConnection");
+        throw new jakarta.jms.IllegalStateException("Operation not supported by a TopicConnection");
     }
 
     @Override
     public QueueSession createQueueSession(boolean transacted, int acknowledgeMode) throws JMSException {
-        throw new javax.jms.IllegalStateException("Operation not supported by a TopicConnection");
+        throw new jakarta.jms.IllegalStateException("Operation not supported by a TopicConnection");
     }
 
 }

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsTopicPublisher.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsTopicPublisher.java
@@ -10,8 +10,8 @@
 
 package org.fusesource.stomp.jms;
 
-import javax.jms.IllegalStateException;
-import javax.jms.*;
+import jakarta.jms.IllegalStateException;
+import jakarta.jms.*;
 
 /**
  * Implementation of a TopicPublisher
@@ -31,7 +31,7 @@ public class StompJmsTopicPublisher extends StompJmsMessageProducer implements T
     /**
      * @return the Topic
      * @throws IllegalStateException
-     * @see javax.jms.TopicPublisher#getTopic()
+     * @see jakarta.jms.TopicPublisher#getTopic()
      */
     public Topic getTopic() throws IllegalStateException {
         checkClosed();
@@ -41,7 +41,7 @@ public class StompJmsTopicPublisher extends StompJmsMessageProducer implements T
     /**
      * @param message
      * @throws JMSException
-     * @see javax.jms.TopicPublisher#publish(javax.jms.Message)
+     * @see jakarta.jms.TopicPublisher#publish(jakarta.jms.Message)
      */
     public void publish(Message message) throws JMSException {
         super.send(message);
@@ -52,7 +52,7 @@ public class StompJmsTopicPublisher extends StompJmsMessageProducer implements T
      * @param topic
      * @param message
      * @throws JMSException
-     * @see javax.jms.TopicPublisher#publish(javax.jms.Topic, javax.jms.Message)
+     * @see jakarta.jms.TopicPublisher#publish(jakarta.jms.Topic, jakarta.jms.Message)
      */
     public void publish(Topic topic, Message message) throws JMSException {
         super.send(topic, message);
@@ -65,7 +65,7 @@ public class StompJmsTopicPublisher extends StompJmsMessageProducer implements T
      * @param priority
      * @param timeToLive
      * @throws JMSException
-     * @see javax.jms.TopicPublisher#publish(javax.jms.Message, int, int, long)
+     * @see jakarta.jms.TopicPublisher#publish(jakarta.jms.Message, int, int, long)
      */
     public void publish(Message message, int deliveryMode, int priority, long timeToLive) throws JMSException {
         super.send(message, deliveryMode, priority, timeToLive);
@@ -79,7 +79,7 @@ public class StompJmsTopicPublisher extends StompJmsMessageProducer implements T
      * @param priority
      * @param timeToLive
      * @throws JMSException
-     * @see javax.jms.TopicPublisher#publish(javax.jms.Topic, javax.jms.Message, int, int, long)
+     * @see jakarta.jms.TopicPublisher#publish(jakarta.jms.Topic, jakarta.jms.Message, int, int, long)
      */
     public void publish(Topic topic, Message message, int deliveryMode, int priority, long timeToLive)
             throws JMSException {

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsTopicSession.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsTopicSession.java
@@ -10,8 +10,8 @@
 
 package org.fusesource.stomp.jms;
 
-import javax.jms.*;
-import javax.jms.IllegalStateException;
+import jakarta.jms.*;
+import jakarta.jms.IllegalStateException;
 
 /**
  * Implementation of a TopicSession
@@ -31,7 +31,7 @@ public class StompJmsTopicSession extends StompJmsSession {
      * @param queue
      * @return
      * @throws JMSException
-     * @see javax.jms.Session#createBrowser(javax.jms.Queue)
+     * @see jakarta.jms.Session#createBrowser(jakarta.jms.Queue)
      */
     public QueueBrowser createBrowser(Queue queue) throws JMSException {
         throw new IllegalStateException("Operation not supported by a TopicSession");
@@ -42,7 +42,7 @@ public class StompJmsTopicSession extends StompJmsSession {
      * @param messageSelector
      * @return
      * @throws JMSException
-     * @see javax.jms.Session#createBrowser(javax.jms.Queue, java.lang.String)
+     * @see jakarta.jms.Session#createBrowser(jakarta.jms.Queue, java.lang.String)
      */
     public QueueBrowser createBrowser(Queue queue, String messageSelector) throws JMSException {
         throw new IllegalStateException("Operation not supported by a TopicSession");
@@ -52,7 +52,7 @@ public class StompJmsTopicSession extends StompJmsSession {
      * @param destination
      * @return
      * @throws JMSException
-     * @see javax.jms.Session#createConsumer(javax.jms.Destination)
+     * @see jakarta.jms.Session#createConsumer(jakarta.jms.Destination)
      */
     public MessageConsumer createConsumer(Destination destination) throws JMSException {
         if (destination instanceof Queue) {
@@ -66,7 +66,7 @@ public class StompJmsTopicSession extends StompJmsSession {
      * @param messageSelector
      * @return
      * @throws JMSException
-     * @see javax.jms.Session#createConsumer(javax.jms.Destination, java.lang.String)
+     * @see jakarta.jms.Session#createConsumer(jakarta.jms.Destination, java.lang.String)
      */
     public MessageConsumer createConsumer(Destination destination, String messageSelector) throws JMSException {
         if (destination instanceof Queue) {
@@ -79,7 +79,7 @@ public class StompJmsTopicSession extends StompJmsSession {
      * @param destination
      * @return
      * @throws JMSException
-     * @see javax.jms.Session#createProducer(javax.jms.Destination)
+     * @see jakarta.jms.Session#createProducer(jakarta.jms.Destination)
      */
     public MessageProducer createProducer(Destination destination) throws JMSException {
         if (destination instanceof Queue) {
@@ -92,7 +92,7 @@ public class StompJmsTopicSession extends StompJmsSession {
      * @param queueName
      * @return
      * @throws JMSException
-     * @see javax.jms.Session#createQueue(java.lang.String)
+     * @see jakarta.jms.Session#createQueue(java.lang.String)
      */
     public Queue createQueue(String queueName) throws JMSException {
         throw new IllegalStateException("Operation not supported by a TopicSession");
@@ -101,7 +101,7 @@ public class StompJmsTopicSession extends StompJmsSession {
     /**
      * @return
      * @throws JMSException
-     * @see javax.jms.Session#createTemporaryQueue()
+     * @see jakarta.jms.Session#createTemporaryQueue()
      */
     public TemporaryQueue createTemporaryQueue() throws JMSException {
         throw new IllegalStateException("Operation not supported by a TopicSession");
@@ -111,7 +111,7 @@ public class StompJmsTopicSession extends StompJmsSession {
      * @param queue
      * @return
      * @throws JMSException
-     * @see javax.jms.QueueSession#createReceiver(javax.jms.Queue)
+     * @see jakarta.jms.QueueSession#createReceiver(jakarta.jms.Queue)
      */
     public QueueReceiver createReceiver(Queue queue) throws JMSException {
         throw new IllegalStateException("Operation not supported by a TopicSession");
@@ -122,7 +122,7 @@ public class StompJmsTopicSession extends StompJmsSession {
      * @param messageSelector
      * @return
      * @throws JMSException
-     * @see javax.jms.QueueSession#createReceiver(javax.jms.Queue, java.lang.String)
+     * @see jakarta.jms.QueueSession#createReceiver(jakarta.jms.Queue, java.lang.String)
      */
     public QueueReceiver createReceiver(Queue queue, String messageSelector) throws JMSException {
         throw new IllegalStateException("Operation not supported by a TopicSession");
@@ -132,7 +132,7 @@ public class StompJmsTopicSession extends StompJmsSession {
      * @param queue
      * @return
      * @throws JMSException
-     * @see javax.jms.QueueSession#createSender(javax.jms.Queue)
+     * @see jakarta.jms.QueueSession#createSender(jakarta.jms.Queue)
      */
     public QueueSender createSender(Queue queue) throws JMSException {
         throw new IllegalStateException("Operation not supported by a TopicSession");

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsTopicSubscriber.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompJmsTopicSubscriber.java
@@ -12,10 +12,10 @@ package org.fusesource.stomp.jms;
 
 import org.fusesource.hawtbuf.AsciiBuffer;
 
-import javax.jms.IllegalStateException;
-import javax.jms.JMSException;
-import javax.jms.Topic;
-import javax.jms.TopicSubscriber;
+import jakarta.jms.IllegalStateException;
+import jakarta.jms.JMSException;
+import jakarta.jms.Topic;
+import jakarta.jms.TopicSubscriber;
 
 /**
  * Implementation of a TopicSubscriber
@@ -38,7 +38,7 @@ public class StompJmsTopicSubscriber extends StompJmsMessageConsumer implements 
     /**
      * @return noLocal flag
      * @throws IllegalStateException
-     * @see javax.jms.TopicSubscriber#getNoLocal()
+     * @see jakarta.jms.TopicSubscriber#getNoLocal()
      */
     public boolean getNoLocal() throws IllegalStateException {
         checkClosed();
@@ -48,7 +48,7 @@ public class StompJmsTopicSubscriber extends StompJmsMessageConsumer implements 
     /**
      * @return the Topic
      * @throws IllegalStateException
-     * @see javax.jms.TopicSubscriber#getTopic()
+     * @see jakarta.jms.TopicSubscriber#getTopic()
      */
     public Topic getTopic() throws IllegalStateException {
         checkClosed();

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompServerAdaptor.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/StompServerAdaptor.java
@@ -12,9 +12,9 @@ package org.fusesource.stomp.jms;
 import org.fusesource.hawtbuf.AsciiBuffer;
 import org.fusesource.stomp.codec.StompFrame;
 
-import javax.jms.JMSException;
-import javax.jms.TemporaryQueue;
-import javax.jms.TemporaryTopic;
+import jakarta.jms.JMSException;
+import jakarta.jms.TemporaryQueue;
+import jakarta.jms.TemporaryTopic;
 import java.util.Map;
 import java.util.UUID;
 

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/jndi/StompJmsInitialContextFactory.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/jndi/StompJmsInitialContextFactory.java
@@ -26,8 +26,8 @@ import java.util.Properties;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.jms.Queue;
-import javax.jms.Topic;
+import jakarta.jms.Queue;
+import jakarta.jms.Topic;
 import javax.naming.Context;
 import javax.naming.NamingException;
 import javax.naming.spi.InitialContextFactory;
@@ -38,7 +38,7 @@ import org.fusesource.stomp.jms.StompJmsTopic;
 
 /**
  * A factory of the StompJms InitialContext which contains
- * {@link javax.jms.ConnectionFactory} instances as well as a child context called
+ * {@link jakarta.jms.ConnectionFactory} instances as well as a child context called
  * <i>destinations</i> which contain all of the current active destinations, in
  * child context depending on the QoS such as transient or durable and queue or
  * topic.

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/message/StompJmsBytesMessage.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/message/StompJmsBytesMessage.java
@@ -16,7 +16,7 @@ import org.fusesource.hawtbuf.DataByteArrayInputStream;
 import org.fusesource.hawtbuf.DataByteArrayOutputStream;
 import org.fusesource.stomp.jms.StompJmsExceptionSupport;
 
-import javax.jms.*;
+import jakarta.jms.*;
 import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
@@ -66,12 +66,12 @@ import java.io.IOException;
  * <CODE>MessageNotWriteableException</CODE> is thrown.
  *
  * @openwire:marshaller code=24
- * @see javax.jms.Session#createBytesMessage()
- * @see javax.jms.MapMessage
- * @see javax.jms.Message
- * @see javax.jms.ObjectMessage
- * @see javax.jms.StreamMessage
- * @see javax.jms.TextMessage
+ * @see jakarta.jms.Session#createBytesMessage()
+ * @see jakarta.jms.MapMessage
+ * @see jakarta.jms.Message
+ * @see jakarta.jms.ObjectMessage
+ * @see jakarta.jms.StreamMessage
+ * @see jakarta.jms.TextMessage
  */
 public class StompJmsBytesMessage extends StompJmsMessage implements BytesMessage {
     protected transient DataByteArrayOutputStream bytesOut;
@@ -190,7 +190,7 @@ public class StompJmsBytesMessage extends StompJmsMessage implements BytesMessag
      *         unsigned 8-bit number
      * @throws JMSException                  if the JMS provider fails to read the message due to
      *                                       some internal error.
-     * @throws javax.jms.MessageEOFException if unexpected end of bytes stream has been
+     * @throws jakarta.jms.MessageEOFException if unexpected end of bytes stream has been
      *                                       reached.
      * @throws MessageNotReadableException   if the message is in write-only mode.
      */

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/message/StompJmsMapMessage.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/message/StompJmsMapMessage.java
@@ -13,10 +13,10 @@ package org.fusesource.stomp.jms.message;
 import org.fusesource.hawtbuf.Buffer;
 import org.fusesource.stomp.jms.util.StompTranslator;
 
-import javax.jms.JMSException;
-import javax.jms.MapMessage;
-import javax.jms.MessageFormatException;
-import javax.jms.MessageNotWriteableException;
+import jakarta.jms.JMSException;
+import jakarta.jms.MapMessage;
+import jakarta.jms.MessageFormatException;
+import jakarta.jms.MessageNotWriteableException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -71,12 +71,12 @@ import java.util.Map;
  * as a <code>char</code> must throw a <code>NullPointerException</code>.
  *
  * @openwire:marshaller code="25"
- * @see javax.jms.Session#createMapMessage()
- * @see javax.jms.BytesMessage
- * @see javax.jms.Message
- * @see javax.jms.ObjectMessage
- * @see javax.jms.StreamMessage
- * @see javax.jms.TextMessage
+ * @see jakarta.jms.Session#createMapMessage()
+ * @see jakarta.jms.BytesMessage
+ * @see jakarta.jms.Message
+ * @see jakarta.jms.ObjectMessage
+ * @see jakarta.jms.StreamMessage
+ * @see jakarta.jms.TextMessage
  */
 public class StompJmsMapMessage extends StompJmsMessage implements MapMessage {
 

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/message/StompJmsMessage.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/message/StompJmsMessage.java
@@ -19,7 +19,7 @@ import org.fusesource.stomp.codec.StompFrame;
 import org.fusesource.stomp.jms.util.TypeConversionSupport;
 import org.fusesource.stomp.jms.util.PropertyExpression;
 
-import javax.jms.*;
+import jakarta.jms.*;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.*;
@@ -29,7 +29,7 @@ import static org.fusesource.hawtbuf.Buffer.ascii;
 import static org.fusesource.stomp.client.Constants.*;
 import static org.fusesource.stomp.codec.StompFrame.*;
 
-public class StompJmsMessage implements javax.jms.Message {
+public class StompJmsMessage implements jakarta.jms.Message {
 
     private static final Map<String, PropertySetter> JMS_PROPERTY_SETERS = new HashMap<String, PropertySetter>();
 
@@ -899,5 +899,24 @@ public class StompJmsMessage implements javax.jms.Message {
 
     public void setConnection(StompJmsConnection connection) {
         this.connection = connection;
+    }
+
+    /*
+     * New Methods from switching to jakarta.jms.
+     */
+    public boolean isBodyAssignableTo(Class c) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public Object getBody(Class c) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public void setJMSDeliveryTime(long l) {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
+    }
+
+    public long getJMSDeliveryTime() {
+        throw new UnsupportedOperationException("Please contact the maintainer to request implementation of this method.");
     }
 }

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/message/StompJmsMessageTransformation.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/message/StompJmsMessageTransformation.java
@@ -12,7 +12,7 @@ package org.fusesource.stomp.jms.message;
 
 import org.fusesource.stomp.jms.*;
 
-import javax.jms.*;
+import jakarta.jms.*;
 import java.util.Enumeration;
 
 /**

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/message/StompJmsObjectMessage.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/message/StompJmsObjectMessage.java
@@ -13,8 +13,8 @@ package org.fusesource.stomp.jms.message;
 import org.fusesource.hawtbuf.Buffer;
 import org.fusesource.stomp.jms.util.StompTranslator;
 
-import javax.jms.JMSException;
-import javax.jms.ObjectMessage;
+import jakarta.jms.JMSException;
+import jakarta.jms.ObjectMessage;
 import java.io.Serializable;
 
 /**
@@ -36,13 +36,13 @@ import java.io.Serializable;
  * written to.
  *
  * @openwire:marshaller code="26"
- * @see javax.jms.Session#createObjectMessage()
- * @see javax.jms.Session#createObjectMessage(Serializable)
- * @see javax.jms.BytesMessage
- * @see javax.jms.MapMessage
- * @see javax.jms.Message
- * @see javax.jms.StreamMessage
- * @see javax.jms.TextMessage
+ * @see jakarta.jms.Session#createObjectMessage()
+ * @see jakarta.jms.Session#createObjectMessage(Serializable)
+ * @see jakarta.jms.BytesMessage
+ * @see jakarta.jms.MapMessage
+ * @see jakarta.jms.Message
+ * @see jakarta.jms.StreamMessage
+ * @see jakarta.jms.TextMessage
  */
 public class StompJmsObjectMessage extends StompJmsMessage implements ObjectMessage {
     protected transient Serializable object;
@@ -98,9 +98,9 @@ public class StompJmsObjectMessage extends StompJmsMessage implements ObjectMess
      * @param newObject the message's data
      * @throws JMSException if the JMS provider fails to set the object due to some
      *                      internal error.
-     * @throws javax.jms.MessageFormatException
+     * @throws jakarta.jms.MessageFormatException
      *                      if object serialization fails.
-     * @throws javax.jms.MessageNotWriteableException
+     * @throws jakarta.jms.MessageNotWriteableException
      *                      if the message is in read-only mode.
      */
 

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/message/StompJmsStreamMessage.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/message/StompJmsStreamMessage.java
@@ -17,7 +17,7 @@ import org.fusesource.hawtbuf.DataByteArrayOutputStream;
 import org.fusesource.stomp.jms.StompJmsExceptionSupport;
 import org.fusesource.stomp.jms.util.MarshallingSupport;
 
-import javax.jms.*;
+import jakarta.jms.*;
 import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.EOFException;
@@ -92,12 +92,12 @@ import java.io.IOException;
  * <code>char</code> must throw a <code>NullPointerException</code>.
  *
  * @openwire:marshaller code="27"
- * @see javax.jms.Session#createStreamMessage()
- * @see javax.jms.BytesMessage
- * @see javax.jms.MapMessage
- * @see javax.jms.Message
- * @see javax.jms.ObjectMessage
- * @see javax.jms.TextMessage
+ * @see jakarta.jms.Session#createStreamMessage()
+ * @see jakarta.jms.BytesMessage
+ * @see jakarta.jms.MapMessage
+ * @see jakarta.jms.Message
+ * @see jakarta.jms.ObjectMessage
+ * @see jakarta.jms.TextMessage
  */
 public class StompJmsStreamMessage extends StompJmsMessage implements StreamMessage {
 

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/message/StompJmsTextMessage.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/message/StompJmsTextMessage.java
@@ -13,9 +13,9 @@ package org.fusesource.stomp.jms.message;
 import org.fusesource.hawtbuf.Buffer;
 import org.fusesource.stomp.jms.StompJmsExceptionSupport;
 
-import javax.jms.JMSException;
-import javax.jms.MessageNotWriteableException;
-import javax.jms.TextMessage;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageNotWriteableException;
+import jakarta.jms.TextMessage;
 import java.io.UnsupportedEncodingException;
 
 import static org.fusesource.stomp.client.Constants.TRANSFORMATION;

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/util/PropertyExpression.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/util/PropertyExpression.java
@@ -14,9 +14,9 @@ import org.fusesource.stomp.jms.StompJmsDestination;
 import org.fusesource.stomp.jms.StompJmsExceptionSupport;
 import org.fusesource.stomp.jms.message.StompJmsMessage;
 
-import javax.jms.DeliveryMode;
-import javax.jms.InvalidDestinationException;
-import javax.jms.JMSException;
+import jakarta.jms.DeliveryMode;
+import jakarta.jms.InvalidDestinationException;
+import jakarta.jms.JMSException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;

--- a/stompjms-client/src/main/java/org/fusesource/stomp/jms/util/StompTranslator.java
+++ b/stompjms-client/src/main/java/org/fusesource/stomp/jms/util/StompTranslator.java
@@ -17,7 +17,7 @@ import org.fusesource.hawtbuf.DataByteArrayOutputStream;
 import org.fusesource.stomp.codec.StompFrame;
 import org.fusesource.stomp.jms.message.*;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.util.Map;

--- a/stompjms-client/src/test/java/org/fusesource/stomp/jms/Assert.java
+++ b/stompjms-client/src/test/java/org/fusesource/stomp/jms/Assert.java
@@ -12,9 +12,9 @@ package org.fusesource.stomp.jms;
 
 import static org.junit.Assert.*;
 
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.TextMessage;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.TextMessage;
 
 public class Assert {
 

--- a/stompjms-client/src/test/java/org/fusesource/stomp/jms/JMSConsumerTest.java
+++ b/stompjms-client/src/test/java/org/fusesource/stomp/jms/JMSConsumerTest.java
@@ -14,7 +14,7 @@ import junit.framework.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jms.*;
+import jakarta.jms.*;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Enumeration;

--- a/stompjms-client/src/test/java/org/fusesource/stomp/jms/JmsStompTest.java
+++ b/stompjms-client/src/test/java/org/fusesource/stomp/jms/JmsStompTest.java
@@ -12,7 +12,7 @@ package org.fusesource.stomp.jms;
 import junit.framework.TestCase;
 import org.fusesource.stomp.client.ApolloBroker;
 
-import javax.jms.*;
+import jakarta.jms.*;
 import javax.naming.InitialContext;
 
 import java.util.Hashtable;

--- a/stompjms-client/src/test/java/org/fusesource/stomp/jms/JmsTestSupport.java
+++ b/stompjms-client/src/test/java/org/fusesource/stomp/jms/JmsTestSupport.java
@@ -14,7 +14,7 @@ import org.apache.activemq.apollo.broker.Broker;
 import org.apache.activemq.apollo.broker.BrokerFactory;
 import org.apache.activemq.apollo.util.ServiceControl;
 
-import javax.jms.*;
+import jakarta.jms.*;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/stompjms-client/src/test/java/org/fusesource/stomp/jms/JmsTransactionTestSupport.java
+++ b/stompjms-client/src/test/java/org/fusesource/stomp/jms/JmsTransactionTestSupport.java
@@ -15,14 +15,14 @@ import static org.fusesource.stomp.jms.Assert.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.jms.Destination;
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.MessageListener;
-import javax.jms.MessageProducer;
-import javax.jms.Session;
-import javax.jms.TextMessage;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.MessageListener;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
 
 import junit.framework.Test;
 

--- a/stompjms-client/src/test/java/org/fusesource/stomp/jms/LoadTestBurnIn.java
+++ b/stompjms-client/src/test/java/org/fusesource/stomp/jms/LoadTestBurnIn.java
@@ -14,7 +14,7 @@ import junit.framework.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jms.*;
+import jakarta.jms.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 

--- a/stompjms-client/src/test/java/org/fusesource/stomp/jms/StompJmsSessionUntransactedTest.java
+++ b/stompjms-client/src/test/java/org/fusesource/stomp/jms/StompJmsSessionUntransactedTest.java
@@ -7,9 +7,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import javax.jms.Session;
-import javax.jms.TemporaryQueue;
-import javax.jms.TemporaryTopic;
+import jakarta.jms.Session;
+import jakarta.jms.TemporaryQueue;
+import jakarta.jms.TemporaryTopic;
 
 import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.any;

--- a/stompjms-website/pom.xml
+++ b/stompjms-website/pom.xml
@@ -18,12 +18,12 @@
   <parent>
     <groupId>org.fusesource.stompjms</groupId>
     <artifactId>stompjms-project</artifactId>
-    <version>1.20-SNAPSHOT</version>
+    <version>1.21</version>
   </parent>
   
   <groupId>org.fusesource.stompjms</groupId>
   <artifactId>stompjms-website</artifactId>
-  <version>1.20-SNAPSHOT</version>
+  <version>1.21</version>
   <packaging>war</packaging>
 
   <name>${project.artifactId}</name>


### PR DESCRIPTION
ActiveMQ uses the presence of the content-length header to distinguish between TextMessage and BytesMessage:
http://activemq.apache.org/stomp.html (See "Working with JMS Text/Bytes Messages and Stomp".)

This is important when forwarding messages between different connector, e.g., from Stomp to OpenWire.

This change adjusts the handling of messages accordingly such that for TextMessages the content-length header is omitted.
